### PR TITLE
include author in XML export

### DIFF
--- a/export/xml-export.html
+++ b/export/xml-export.html
@@ -87,7 +87,7 @@ if( ! defined($session{'userid'}) ) {
       
       # Get the valsi best guesses list.
       my $valsiquery = $dbh->prepare("
-          SELECT v.word, vbg.definitionid, c.rafsi, c.selmaho, c.definition, c.notes, t.descriptor
+          SELECT v.word, vbg.definitionid, c.rafsi, c.selmaho, c.definition, c.notes, t.descriptor, u.username, u.realname
           FROM valsibestguesses vbg
           JOIN valsi v
             ON v.valsiid = vbg.valsiid
@@ -95,6 +95,8 @@ if( ! defined($session{'userid'}) ) {
             ON c.definitionid = vbg.definitionid
           JOIN valsitypes t
             ON t.typeid = v.typeid
+          JOIN users u
+            ON v.userId = u.userId
           WHERE vbg.langid=$langid
           ORDER BY v.word");
       
@@ -137,6 +139,18 @@ if( ! defined($session{'userid'}) ) {
       	massage(${$valsirow}{'selmaho'})
       	. "</selmaho>";
           }
+          
+          $entry .= "<user>" .
+          "<username>" .
+          massage("${valsirow}{'username'}") .
+          "</username>";
+          if( ${valsirow}{'realname'} )
+          {
+              $entry .= "<realname>" .
+              massage("${valsirow}{'realname'}") .
+              "</realname>";
+          }
+          $entry .= "</user>";
       
           $entry .= "<definition>" .
           massage("${$valsirow}{'definition'}") .


### PR DESCRIPTION
This PR adds a <user> section under each <valsi> in the XML exports. It contains the username (<username>) of the user who created the word, and their name (<realname>) if available.

@djeik (la tsani) asked for this and I have wanted it in the past as well. The information is there in jbovlaste already, and it's sometimes useful to have the author in our IRC bots and other things that consume the XML.

**I have not tested this in any way, shape or form, and I don't really know Perl!** I just went off the database schema from design/jbovlaste.sql and followed the style of the surrounding code.
