### PR TITLE
untested fix for bug introduced by fix for #67

### DIFF
--- a/lookup/lookup.pl
+++ b/lookup/lookup.pl
@@ -353,13 +353,13 @@ sub SendForm1 {
         <select name="Strategy">
 EOF
     foreach my $x (split(/\t/,$Choices{"Strategy"})) {
-	print "        <option value=\"$St{$x}\"";
-	if (defined($in{"Strategy"}) && defined($St{$x})){
-          if ($in{"Strategy"} eq $St{$x}) {
-	    print " selected";
-          }
-	}
-	print ">$x\n";
+        print "        <option value=\"$St{$x}\"";
+        if (defined($in{"Strategy"}) && defined($St{$x})){
+            if ($in{"Strategy"} eq $St{$x}) {
+                print " selected";
+            }
+        }
+        print ">$x\n";
     }
     print <<EOF2;
         </select>
@@ -367,16 +367,18 @@ EOF
         <b>Database:</b></td><td>
         <select name="Database">
 EOF2
-    my @sorted_dbs =
-      sort {lc $a cmp lc $b}
-      map { s/^\s+|\s+$//g; $_; }
-      (split(/\t/, $Choices{"Database"}));
-    foreach my $x (@sorted_dbs) {
-	print "        <option value=\"$Db{$x}\"";
-	if ($in{"Database"} eq $Db{$x}) {
-	    print " selected";
-	}
-	print ">$x\n";
+    my %unsorted_dbs =
+        map { my $a = $b = $_;
+              $a =~ s/^\s+|\s+$//g;
+              ($a => $b); }
+            (split(/\t/, $Choices{"Database"}));
+    foreach my $k (sort {lc $a cmp lc $b} keys %unsorted_dbs) {
+        my $v = $unsorted_dbs{$k};
+        print "        <option value=\"$Db{$v}\"";
+        if ($in{"Database"} eq $Db{$v}) {
+            print " selected";
+        }
+        print ">$k\n";
     }
     print <<EOF3;
         </select>


### PR DESCRIPTION
I am not sure I agree that #67 was a bug -- I kind of liked having "All" and "Virtual combination" at the top (not that I ever use that interface...).

That aside, the fix for #67 introduced a bug, in that (nearly) all the option values are blank, which means the database is stuck on "All" and you can't change it. This is because the language name is used as a key into the %Db hash to look up the option value, but once the language name is trimmed, the hash lookup breaks. This bandaid fix keeps the untrimmed value around for use in the foreach loop (in a civilized language, we'd use zipWith :) ).

I don't have a running instance of jbovlaste so obviously this fix hasn't been tested. I "tested" it in a REPL with fake data, but I don't know what the real data looks like. And I don't know Perl, so YMMV.

I also fixed the indentation of the Strategy and Database loops.
