### PR TITLE
make undefined valsi links red

### DIFF
--- a/autohandler.in
+++ b/autohandler.in
@@ -39,6 +39,7 @@ what happened leading up to this. Just in case.
            background-position:bottom right; }
     -->
     .form-notice { border: .1em solid red; background: #FCC; color: black; padding: .5em;  }
+    a.undefined { color: red }
  </style>
   <meta name="keywords" content="jbovlaste lojban dictionary" />
   <!-- Don't bitch about my XHTML, and I won't gnaw off your head.

--- a/lib/Wiki.pm
+++ b/lib/Wiki.pm
@@ -219,11 +219,11 @@ sub wordreferencegenerate {
 
     if( $valsiid != 0 )
     {
-	return sprintf( "<a href=\"../dict/%s?bg=1;langidarg=%s\">%s</a>",
+	return sprintf( "<a class=\"defined\" href=\"../dict/%s?bg=1;langidarg=%s\">%s</a>",
 		utils::armorurl($word), $langid,  $alttxt
 		);
     } else {
-	return sprintf( "<a href=\"../dict/%s?bg=1;langidarg=%s\">Word %s not found in database.</a>",
+	return sprintf( "<a class=\"undefined\" href=\"../dict/%s?bg=1;langidarg=%s\">%s</a>",
 		utils::armorurl($word), $langid,  $alttxt
 		);
     }


### PR DESCRIPTION
I'm really not a fan of jbovlaste yelling WORD NOT FOUND IN DATABASE all the time when you were just trying to quote a phrase or even intentionally link to an undefined word without wrecking your sentence structure.

See [here](http://jbovlaste.lojban.org/comments.html?valsi=29003) for a relatively innocuous example.

This tiny patch removes the not-found text and simply changes the color of the link via CSS. The meaning of a red link should be familiar to the vast majority of internet users due to Wikipedia's precedent.

As always, this is untested (except for fiddling in the Firefox web console to make sure my CSS works) because I have no idea how to set up a jbovlaste test environment.