### PR TITLE
localize $/ in run_vlatai

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -80,19 +80,16 @@ sub vlatai {
 
 sub run_vlatai {
     my $valsi = shift;
-    my $tmp = $/;
-    undef $/; # slurp mode
     my $safevalsi = $valsi;
     $safevalsi =~ s/[^\'\w, ]//g; # NOTE: spaces are significant
     $safevalsi =~ s/\'/\\\'/g;
     if (open(VLATAI, "/usr/local/bin/vlatai.py $safevalsi|")) {
+      local $/ = undef; # slurp mode
       my $type = <VLATAI>;
       close(VLATAI);
-      $/ = $tmp;
       chomp $type;
       return $type || "nalvla";
     }
-    $/ = $tmp;
     warn "Failed to run vlatai(/usr/local/bin/vlatai.py): $!";
     return "nalvla";
 }


### PR DESCRIPTION
localize $/ in run_vlatai via `local` which sets it to undef for the
given block, thus removing the now needless $tmp:

	$ perl -wle '$/ = "mlatu"; { local $/; print $/ } print $/'
	Use of uninitialized value $/ in print at -e line 1.

	mlatu