### PR TITLE
Set Content-Disposition header on XML export

### DIFF
--- a/export/xml-export.html
+++ b/export/xml-export.html
@@ -68,6 +68,7 @@ if( ! defined($session{'userid'}) ) {
       }
 
       $r->content_type('application/xml; charset=utf-8');
+      $r->header_out('Content-Disposition' => "attachment; filename=\"jbovlaste-$lang.xml\"");
 
       our $unofficialwarning = 'unofficial="true" ';
       my $langrealname = $dbh->selectrow_array("SELECT realname FROM


### PR DESCRIPTION
Now that [xml.html](https://jbovlaste.lojban.org/export/xml.html) has a button instead of `<a>` links, I can no longer "right-click + save as" (see #208).

This PR adds a HTTP header that makes sure the file is downloaded rather than navigated to.

