### PR TITLE
Remove dots around "jbovlaste" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# la.jbovlaste.
-**_la.jbovlaste._** is the dictionary editing system for the [constructed language Lojban](http://lojban.org/). It is available online at http://jbovlaste.lojban.org/
+# la jbovlaste
+**_la jbovlaste_** is the dictionary editing system for the [constructed language Lojban](http://lojban.org/). It is available online at http://jbovlaste.lojban.org/
 
 In Lojban, [_jbovlaste_](http://jbovlaste.lojban.org/lookup.pl?Form=lookup.pl2&Database=*&Query=jbovlaste) means "Lojbanic dictionary" and is derived from the Lojban words [_lo**jbo**_ "Lojbanic"](http://jbovlaste.lojban.org/lookup.pl?Form=lookup.pl2&Database=*&Query=lojbo), [_**val**si_ "word"](http://jbovlaste.lojban.org/lookup.pl?Form=lookup.pl2&Database=*&Query=valsi) and [_li**ste**_ "list"](http://jbovlaste.lojban.org/lookup.pl?Form=lookup.pl2&Database=*&Query=liste) using their [_rafsi_](https://mw.lojban.org/papri/rafsi) short forms _jbo_ + _vla_ + _ste_.
 
@@ -9,7 +9,7 @@ The Lojban dictionary is prescriptive, unlike the descriptive dictionaries for m
 
 The Lojban dictionary is editable by its users if they have [made an account on the site](http://jbovlaste.lojban.org/newaccount.html). No user account is necessary to view Lojbanic word definitons.
 
-Many other dictionaries and tools are based on _la.jbovlaste._; refer to the [Lojban website](http://lojban.org/) for more information.
+Many other dictionaries and tools are based on jbovlaste; refer to the [Lojban website](http://lojban.org/) for more information.
 
 The Lojban wiki page devoted to jbovlaste is https://mw.lojban.org/papri/la_jbovlaste
 


### PR DESCRIPTION
The rule about dots surrounding names — dotside or no — refers to _cmevla_, not to "anything that follows `la`". And `jbovlaste` is a brivla, not a cmevla.

(It's not strictly _wrong_ to pause here, but it betrays some confusion about the point of the dots, and propagates the wrong idea about when dots are necessary.)

Compare to [section 6.2 in CLL](https://lojban.org/publications/cll/cll_v1.1_xhtml-section-chunks/section-basic-descriptors.html) which talks about `la cribe`, not `la .cribe.`.
